### PR TITLE
Using forecast from step 1( forecast information unavailable at step 0)

### DIFF
--- a/lagtraj/domain/sources/era5.py
+++ b/lagtraj/domain/sources/era5.py
@@ -358,7 +358,7 @@ def _build_single_level_fc_query(date, bbox, latlon_sampling):
         "area": [bbox.lat_max, bbox.lon_min, bbox.lat_min, bbox.lon_max],
         "grid": "{}/{}".format(latlon_sampling.lat, latlon_sampling.lon),
         "type": "fc",
-        "step": "0/1/2/3/4/5/6/7/8/9/10/11",
+        "step": "1/2/3/4/5/6/7/8/9/10/11/12",
         "format": "netcdf",
     }
 
@@ -393,10 +393,9 @@ def _build_model_level_fc_query(date, bbox, latlon_sampling):
         "stream": "oper",
         "time": "06:00:00/18:00:00",
         "type": "fc",
-        "time": "06:00:00/18:00:00",
         "area": [bbox.lat_max, bbox.lon_min, bbox.lat_min, bbox.lon_max,],
         "grid": "{}/{}".format(latlon_sampling.lat, latlon_sampling.lon),
-        "step": "0/1/2/3/4/5/6/7/8/9/10/11",
+        "step": "1/2/3/4/5/6/7/8/9/10/11/12",
         "format": "netcdf",
     }
 


### PR DESCRIPTION
I.e. using step 1-12 instead of 0-11

Hi @leifdenby, this is a minor issue: some fields are unavailable at the first step of the forecast. I have also removed a duplicate dictionary entry in the dictionary request. First comparison against Roel's forcings looks promising, will fill you in on this later.