### PR TITLE
Input loading improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ for downloading domain data run lagtraj.domain.download as follows:
 integration and forcing calculation being available before trajectories are
 integrated. This was done to reduce the number of data requests required to the
 data storage backends (e.g. ECMWF), but does mean that *the expected extent
-that a trajetory will reach must been known before performining a trajectory
+that a trajectory will reach must been known before performining a trajectory
 integration*, otherwise `lagtraj` will issue a warning when the edge of the
 available domain is reached.
 
-Either create your own domain definition in `data/domains/<domain_name>/meta.yaml` and run
+Either create your own domain definition in `data/domains/<domain_name>.yaml` and run
 
 ```bash
 $> python -m lagtraj.domain.download <domain_name> [start date (yyyy-mm-dd)] [end date (yyyy-mm-dd)]
@@ -94,8 +94,19 @@ $> python -m lagtraj.domain.download lagtraj://eurec4a_north_atlantic [start dat
 
 ## 2. Producing a trajectory
 
+Once you have downloaded the required domain data you can either create
+a trajectory definition in `data/trajectories/<trajectory_name>.yaml` and run
+
 ```bash
 $> python -m lagtraj.trajectory.create <trajectory_name>
+```
+
+Or use one of the domain definitions included with `lagtraj` (e.g.
+`eurec4a_20191209_12_lag`
+
+
+```bash
+$> python -m lagtraj.trajectory.create lagtraj://eurec4a_20191209_12_lag
 ```
 
 ## 3. Producing forcing profiles

--- a/lagtraj/input_definitions/load.py
+++ b/lagtraj/input_definitions/load.py
@@ -1,8 +1,25 @@
 import yaml
 import sys
+from pathlib import Path
 
 from . import validate_input, build_input_definition_path, examples as input_examples
 from .. import DATA_TYPE_PLURAL
+
+FOLDER_STRUCTURE_EXAMPLE = """
+data
+├── domains
+│   ├── eurec4a_circle_eul.yaml
+│   └── eurec4a_circle_eul_data
+│       ├── an_model_2020-01-01.nc
+│       :
+│       └── fc_single_2020-01-03.nc
+├── forcings
+│   ├── eure4a_20191209_12_eul.yaml
+│   └── eure4a_20191209_12_eul.nc
+└── trajectories
+    ├── eure4a_20191209_12_eul.yaml
+    └── eure4a_20191209_12_eul.nc
+"""
 
 
 def load_definition(input_name, input_type, root_data_path, required_fields):
@@ -38,6 +55,16 @@ def load_definition(input_name, input_type, root_data_path, required_fields):
             print()
             input_examples.print_available(input_types=[input_type_plural])
             sys.exit(1)
+    elif input_name.endswith(".yaml") or input_name.endswith(".yml"):
+        # assume we've been passed a full path
+        input_local_path = Path(input_name)
+        raise Exception(
+            "You provided an absolute path to an input"
+            " yaml file instead of providing the name"
+            " of the input.\nFor for example a trajectory"
+            " stored in data/trajectories/eurec4a_20191209_12_lin.yaml"
+            " this should be loaded by name as `eurec4a_20191209_12_lin`"
+        )
     else:
         input_local_path = build_input_definition_path(
             root_data_path=root_data_path, input_name=input_name, input_type=input_type,

--- a/lagtraj/input_definitions/load.py
+++ b/lagtraj/input_definitions/load.py
@@ -55,20 +55,40 @@ def load_definition(input_name, input_type, root_data_path, required_fields):
             print()
             input_examples.print_available(input_types=[input_type_plural])
             sys.exit(1)
-    elif input_name.endswith(".yaml") or input_name.endswith(".yml"):
-        # assume we've been passed a full path
-        input_local_path = Path(input_name)
-        raise Exception(
-            "You provided an absolute path to an input"
-            " yaml file instead of providing the name"
-            " of the input.\nFor for example a trajectory"
-            " stored in data/trajectories/eurec4a_20191209_12_lin.yaml"
-            " this should be loaded by name as `eurec4a_20191209_12_lin`"
-        )
     else:
-        input_local_path = build_input_definition_path(
-            root_data_path=root_data_path, input_name=input_name, input_type=input_type,
-        )
+        if input_name.endswith(".yaml") or input_name.endswith(".yml"):
+            # assume we've been passed a full path
+            input_local_path = Path(input_name)
+            # assume we've been passed a full path
+            input_local_path = Path(input_name)
+            if not input_local_path.exists():
+                raise Exception(
+                    "You provided an absolute path to an input"
+                    " yaml file, but that file doesn't appear"
+                    " to exist. Maybe you intended to just"
+                    " load this input definition by name instead?"
+                )
+            # check that this provided yaml-file is in the correct folder
+            # structure
+            input_type_plural = DATA_TYPE_PLURAL[input_type]
+            if not (
+                input_local_path.parent.parent.name == "data"
+                and input_local_path.parent.name == input_type_plural
+            ):
+                raise Exception(
+                    "The yaml input-file you provided does not"
+                    " exist in the correct direction structure."
+                    " lagtraj assumes that all data is stored in"
+                    " a directory structure as follows (so that"
+                    " so that the relevant input data and output"
+                    f" can be found by lagtraj): \n{FOLDER_STRUCTURE_EXAMPLE}"
+                )
+        else:
+            input_local_path = build_input_definition_path(
+                root_data_path=root_data_path,
+                input_name=input_name,
+                input_type=input_type,
+            )
         with open(input_local_path) as fh:
             params = yaml.load(fh, Loader=yaml.FullLoader)
 

--- a/tests/test_input_definition_loading.py
+++ b/tests/test_input_definition_loading.py
@@ -1,0 +1,28 @@
+import shutil
+import tempfile
+from pathlib import Path
+
+from lagtraj.input_definitions import build_input_definition_path
+from lagtraj.trajectory import load as traj_load
+from lagtraj.input_definitions.examples import P_ROOT as p_examples_root
+
+
+def test_loading_local_file_by_name():
+    tempdir = tempfile.TemporaryDirectory()
+    testdata_dir = Path(tempdir.name)
+
+    input_name = "eurec4a_20191209_12_eul"
+    input_type = "trajectory"
+
+    # copy an example out from the lagtraj input examples
+    p_example = build_input_definition_path(
+        input_name=input_name, input_type=input_type, root_data_path=p_examples_root,
+    )
+    p_local = build_input_definition_path(
+        input_name=input_name, input_type=input_type, root_data_path=testdata_dir
+    )
+    p_local.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(p_example, p_local)
+
+    # and check we can load it - by name
+    traj_load.load_definition(root_data_path=testdata_dir, name=input_name)


### PR DESCRIPTION
- clarifies in README that all input yaml files should be referenced **by name** and not directly by the absolute file path
- makes it possible to reference input yaml files by absolute path, but checks that this yaml file exists in the correct folder structure so that other input files and input data can be found
- adds a test to ensure loading by name keeps working