### PR TITLE
Pin pandas version to v1.0.5

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -36,6 +36,8 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+#   - name: Setup tmate session
+#     uses: mxschmitt/action-tmate@v2
     - name: Test with pytest
       run: |
         pip install pytest |

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ datetime
 numpy
 pyyaml
 cdsapi
-pandas
+pandas<=1.0.5  # datetime indexing broken with 1.1.0, https://github.com/pydata/xarray/issues/4283
 scipy
 argparse
 dask[array]


### PR DESCRIPTION
There is an issue with pandas and xarray wrt to datetime indexing
(https://github.com/pydata/xarray/issues/4283), until this is fixed in
xarray we'll pin the pandas version.