### PR TITLE
Suggestion for handling nested dictionaries in netCDF attributes

### DIFF
--- a/lagtraj/trajectory/create.py
+++ b/lagtraj/trajectory/create.py
@@ -12,7 +12,7 @@ from ..domain.load import load_data as load_domain_data
 from ..domain.download import download_complete
 from ..utils import optional_debugging, validation
 from ..domain.sources.era5.load import ERA5DataSet
- 
+
 """ Routines for creating a trajectory
 
 # - Implement different strategies (single height, weighted over heights, in
@@ -27,16 +27,16 @@ from ..domain.sources.era5.load import ERA5DataSet
 """
 
 
-def _append_dictionary_to_attrs(input_dictionary, output_ds, init_str=''):
+def _append_dictionary_to_attrs(input_dictionary, output_ds, init_str=""):
     for k, v in input_dictionary.items():
         if isinstance(v, dict):
-            _append_dictionary_to_attrs(v, output_ds, init_str=str(k)+'_')
+            _append_dictionary_to_attrs(v, output_ds, init_str=str(k) + "_")
         elif isinstance(v, xr.Dataset) or isinstance(v, ERA5DataSet):
-            output_ds.attrs[init_str+k] = str(type(v))
+            output_ds.attrs[init_str + k] = str(type(v))
         elif isinstance(v, xr.DataArray):
-            output_ds.attrs[init_str+k] = v.values
+            output_ds.attrs[init_str + k] = v.values
         else:
-            output_ds.attrs[init_str+k] = v
+            output_ds.attrs[init_str + k] = v
 
 
 def create_trajectory(origin, trajectory_type, da_times, **kwargs):


### PR DESCRIPTION
Here is a suggestion. It currently gives:

```
// global attributes:
		:trajectory_type = "lagrangian" ;
		:velocity_method = "single_height_level" ;
		:velocity_method_kwargs_height = 500. ;
		:ds_domain = "<class \'lagtraj.domain.sources.era5.load.ERA5DataSet\'>" ;
		:name = "lagtraj://eurec4a_20200202_12_lag" ;
		:domain_name = "lagtraj://eurec4a_circle_eul" ;
```
Not sure whether to get rid of "kwargs" in "velocity_method_kwargs_height". For a single data array, it extracts values to the attribute. By the way, we may want to rename ERA5DataSet to ERA5Dataset for greater consistency with xarray (which uses "DataArray", but "Dataset").