### PR TITLE
Ensure output doesn't raise warnings in ncview

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -40,5 +40,5 @@ jobs:
 #     uses: mxschmitt/action-tmate@v2
     - name: Test with pytest
       run: |
-        pip install pytest psutil |
+        pip install pytest |
         python -m pytest

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -20,6 +20,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.6
+    - name: Install ncview
+      run: sudo apt-get install ncview
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -40,5 +40,5 @@ jobs:
 #     uses: mxschmitt/action-tmate@v2
     - name: Test with pytest
       run: |
-        pip install pytest |
+        pip install pytest psutil |
         python -m pytest

--- a/lagtraj/forcings/create.py
+++ b/lagtraj/forcings/create.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from .. import DEFAULT_ROOT_DATA_PATH
 from . import profile_calculation, load, build_forcing_data_path
 from .utils.levels import make_levels
-from ..utils import optional_debugging
+from ..utils import optional_debugging, validation
 from ..domain.load import load_data as load_domain_data
 from ..trajectory.load import load_data as load_trajectory_data
 
@@ -99,7 +99,9 @@ def export(file_path, ds_forcing, format):
     # TODO: add hightune format export here
 
     Path(file_path).parent.mkdir(parents=True, exist_ok=True)
-    ds_forcing.to_netcdf(file_path)
+    validation.validate_forcing_profiles(ds_forcing_profiles=ds_forcing)
+    encoding = validation.build_valid_encoding(ds=ds_forcing)
+    ds_forcing.to_netcdf(file_path, encoding=encoding)
 
 
 def main():

--- a/lagtraj/trajectory/create.py
+++ b/lagtraj/trajectory/create.py
@@ -120,7 +120,8 @@ def cli(data_path, trajectory_name):
     )
 
     validation.validate_trajectory(ds_traj=ds_trajectory)
-    ds_trajectory.to_netcdf(trajectory_data_path)
+    encoding = validation.build_valid_encoding(ds=ds_trajectory)
+    ds_trajectory.to_netcdf(trajectory_data_path, encoding=encoding)
     print("Saved trajectory to `{}`".format(trajectory_data_path))
 
 

--- a/lagtraj/utils/output/ncview_validation.py
+++ b/lagtraj/utils/output/ncview_validation.py
@@ -1,0 +1,69 @@
+"""
+Ensure that output of lagtraj doesn't produce errors in ncview by setting the
+correct encoding for output and running ncview to check its output
+"""
+import tempfile
+import signal
+import psutil
+import subprocess
+import os
+
+
+NCVIEW_COMPATIBLE_NETCDF_ENCODING = dict(
+    time=dict(dtype="float64", units="seconds since 1970-01-01 00:00:00")
+)
+
+
+def build_valid_encoding(ds):
+    encoding = {}
+    for v in list(ds.data_vars) + list(ds.coords):
+        try:
+            ds[
+                v
+            ].dt  # try accessing the datetime accessor, only datetime types have this
+            encoding[v] = dict(NCVIEW_COMPATIBLE_NETCDF_ENCODING["time"])
+        except TypeError:
+            pass
+    return encoding
+
+
+PROBLEM_STRINGS = [
+    "ncview: netcdf_dim_value: unknown data type",
+]
+
+
+def check_for_ncview_warnings(ds):
+    """
+    Check for warnings when opening `ds` written to at netCDF file
+    """
+    fhnc = tempfile.NamedTemporaryFile(delete=False, suffix=".nc")
+    encoding = build_valid_encoding(ds=ds)
+    ds.to_netcdf(fhnc, encoding=encoding)
+    fhnc.close()
+
+    nc_filename = fhnc.name
+
+    call = f"ncview {nc_filename}"
+    p = subprocess.Popen(
+        call.split(" "),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    def get_cpu_usage():
+        # watch the ncview process for a second and see how much cpu it's using
+        return psutil.Process(p.pid).cpu_percent(interval=1.0)
+
+    # wait until ncview has finished loading
+    while get_cpu_usage() > 0.1:
+        continue
+
+    # then kill it
+    p.send_signal(signal.SIGINT)
+
+    # appears ncview writes all its output to stderr...
+    _, stderr = p.communicate()
+
+    if any([s in stderr for s in PROBLEM_STRINGS]):
+        raise Exception(f"ncview is not happy with the provided dataset: {stderr}")

--- a/lagtraj/utils/validation.py
+++ b/lagtraj/utils/validation.py
@@ -1,4 +1,5 @@
 from lagtraj.forcings.profile_calculation import FORCING_VARS
+from .output.ncview_validation import check_for_ncview_warnings, build_valid_encoding
 
 
 def validate_trajectory(ds_traj):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ argparse
 dask[array]
 asciitree
 isodate
+psutil

--- a/tests/test_forcing_profiles_extraction.py
+++ b/tests/test_forcing_profiles_extraction.py
@@ -31,3 +31,4 @@ def test_create_forcing_linear_trajectory(
     )
 
     validation.validate_forcing_profiles(ds_forcing)
+    validation.check_for_ncview_warnings(ds=ds_forcing)

--- a/tests/test_trajectory_creation.py
+++ b/tests/test_trajectory_creation.py
@@ -29,6 +29,7 @@ def test_create_linear_trajectory(ds_domain_test, ds_trajectory_linear):
     ds_traj.attrs["name"] = "test_trajectory"
     ds_traj.attrs["domain_name"] = "test_domain_data"
     validation.validate_trajectory(ds_traj)
+    validation.check_for_ncview_warnings(ds=ds_traj)
 
 
 def test_create_lagrangian_trajectory(ds_domain_test):


### PR DESCRIPTION
https://github.com/EUREC4A-UK/lagtraj/issues/50

Adds functionality to run create ncview-compatible encoding of output
netCDF-files and runs ncview to ensure that ncview doesn't complain
about the written files.