### PR TITLE
use origin time as reference in netcdf output

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -28,7 +28,7 @@ jobs:
         pip install -r requirements.txt
     - name: Check formatting with black
       run: |
-        pip install black
+        pip install black==19.10b0
         # check that formatting is ok with black
         black --check .
     - name: Lint with flake8

--- a/lagtraj/utils/output/ncview_validation.py
+++ b/lagtraj/utils/output/ncview_validation.py
@@ -15,10 +15,7 @@ def build_valid_encoding(ds):
             # ncview prefers have the time in seconds (as floats)
             encoding[v] = dict(dtype="float64")
             if v == "time":
-                if "origin_datetime" in ds.data_vars:
-                    t_ref = ds.origin_datetime
-                else:
-                    t_ref = ds.time.isel(time=0)
+                t_ref = ds.time.isel(time=0)
                 encoding[v]["units"] = t_ref.dt.strftime(
                     "seconds since %y-%m-%d %H:%M:%S"
                 ).item()


### PR DESCRIPTION
Use `origin_datetime` to set units for `time` coordinate in netCDF output. This only applies to trajectories since forcing files don't currently include an `origin_datetime`, there the first timestep is used instead.

Closes #53 