### PR TITLE
Add retry rate for downloading domain data

### DIFF
--- a/lagtraj/domain/download.py
+++ b/lagtraj/domain/download.py
@@ -1,10 +1,12 @@
 import dateutil.parser
 from pathlib import Path
+from time import sleep
 
 from .sources import era5
 from .. import DEFAULT_ROOT_DATA_PATH
 from . import LatLonBoundingBox, LatLonSamplingResolution, build_domain_data_path
 from .load import load_definition
+from ..trajectory.load import load_definition as load_traj_definition
 
 
 def download(
@@ -77,25 +79,66 @@ def download_complete(root_data_path, domain_name):
         )
 
 
-if __name__ == "__main__":
+def _run_cli(timedomain_lookup="by_arguments"):
     import argparse
 
     argparser = argparse.ArgumentParser()
-    argparser.add_argument("domain")
-    argparser.add_argument("start_date", type=dateutil.parser.parse)
-    argparser.add_argument("end_date", type=dateutil.parser.parse)
+    if timedomain_lookup == "by_arguments":
+        argparser.add_argument("domain")
+        argparser.add_argument("start_date", type=dateutil.parser.parse)
+        argparser.add_argument("end_date", type=dateutil.parser.parse)
+    elif timedomain_lookup == "by_trajectory":
+        argparser.add_argument("trajectory")
+    else:
+        raise NotImplementedError(timedomain_lookup)
+
     argparser.add_argument(
         "-d", "--data-path", default=DEFAULT_ROOT_DATA_PATH, type=Path
     )
     argparser.add_argument(
         "-o", "--overwrite", dest="l_overwrite", action="store_true", default=False
     )
+    argparser.add_argument(
+        "--retry-rate", default=None, type=float,
+        help="Retry time delay (in minutes) when some files are still processing"
+    )
     args = argparser.parse_args()
 
-    download_named_domain(
-        data_path=args.data_path,
-        name=args.domain,
-        start_date=args.start_date,
-        end_date=args.end_date,
-        overwrite_existing=args.l_overwrite,
-    )
+    if timedomain_lookup == "by_arguments":
+        domain = args.domain
+        t_min = args.start_date
+        t_max = args.end_date
+    elif timedomain_lookup == "by_trajectory":
+        traj_defn = load_traj_definition(
+            root_data_path=args.data_path, name=args.trajectory
+        )
+        domain = traj_defn.domain
+        t_min = traj_defn.origin.datetime - traj_defn.duration.backward
+        t_max = traj_defn.origin.datetime + traj_defn.duration.forward
+    else:
+        raise NotImplementedError(timedomain_lookup)
+
+    def attempt_download():
+        download_named_domain(
+            data_path=args.data_path,
+            name=domain,
+            start_date=t_min,
+            end_date=t_max,
+            overwrite_existing=args.l_overwrite,
+        )
+
+    if args.retry_rate is not None:
+        while True:
+            attempt_download()
+            if download_complete(args.data_path, domain_name=domain):
+                break
+            else:
+                print(f"Sleeping {args.retry_rate}min...")
+                sleep(args.retry_rate * 60.0)
+                print("Retrying download")
+    else:
+        attempt_download()
+
+
+if __name__ == "__main__":
+    _run_cli(timedomain_lookup="by_arguments")

--- a/lagtraj/domain/download.py
+++ b/lagtraj/domain/download.py
@@ -99,8 +99,10 @@ def _run_cli(timedomain_lookup="by_arguments"):
         "-o", "--overwrite", dest="l_overwrite", action="store_true", default=False
     )
     argparser.add_argument(
-        "--retry-rate", default=None, type=float,
-        help="Retry time delay (in minutes) when some files are still processing"
+        "--retry-rate",
+        default=None,
+        type=float,
+        help="Retry time delay (in minutes) when some files are still processing",
     )
     args = argparser.parse_args()
 

--- a/lagtraj/domain/download_by_trajectory.py
+++ b/lagtraj/domain/download_by_trajectory.py
@@ -1,35 +1,5 @@
-from pathlib import Path
-
-
-from .. import DEFAULT_ROOT_DATA_PATH
-from .download import download_named_domain
-from ..trajectory.load import load_definition as load_traj_definition
+from .download import _run_cli
 
 
 if __name__ == "__main__":
-    import argparse
-
-    argparser = argparse.ArgumentParser()
-    argparser.add_argument("trajectory")
-    argparser.add_argument(
-        "-d", "--data-path", default=DEFAULT_ROOT_DATA_PATH, type=Path
-    )
-    argparser.add_argument(
-        "-o", "--overwrite", dest="l_overwrite", action="store_true", default=False
-    )
-    args = argparser.parse_args()
-
-    traj_defn = load_traj_definition(
-        root_data_path=args.data_path, name=args.trajectory
-    )
-
-    t_min = traj_defn.origin.datetime - traj_defn.duration.backward
-    t_max = traj_defn.origin.datetime + traj_defn.duration.forward
-
-    download_named_domain(
-        data_path=args.data_path,
-        name=traj_defn.domain,
-        start_date=t_min,
-        end_date=t_max,
-        overwrite_existing=args.l_overwrite,
-    )
+    _run_cli(timedomain_lookup="by_trajectory")

--- a/lagtraj/domain/sources/era5/download.py
+++ b/lagtraj/domain/sources/era5/download.py
@@ -102,7 +102,7 @@ def download_data(
 
 def all_data_is_downloaded(path):
     c = RequestFetchCDSClient()
-    return len(_get_files(path=path, c=c, with_status=['queued', 'running'])) == 0
+    return len(_get_files(path=path, c=c, with_status=["queued", "running"])) == 0
 
 
 def _get_files(path, c, debug=False, with_status=None):

--- a/lagtraj/domain/sources/era5/download.py
+++ b/lagtraj/domain/sources/era5/download.py
@@ -73,7 +73,7 @@ def download_data(
         with open(path / DATA_REQUESTS_FILENAME, "w") as fh:
             fh.write(yaml.dump(download_requests))
 
-    files_to_download = _get_files_to_download(path=path, c=c, debug=True)
+    files_to_download = _get_files(path=path, c=c, debug=True, with_status="completed")
 
     if len(files_to_download) > 0:
         print("Downloading files which are ready...")
@@ -102,10 +102,10 @@ def download_data(
 
 def all_data_is_downloaded(path):
     c = RequestFetchCDSClient()
-    return len(_get_files_to_download(path=path, c=c)) == 0
+    return len(_get_files(path=path, c=c, with_status=['queued', 'running'])) == 0
 
 
-def _get_files_to_download(path, c, debug=False):
+def _get_files(path, c, debug=False, with_status=None):
     meta_filename = path / DATA_REQUESTS_FILENAME
     if not meta_filename.exists():
         return []
@@ -113,7 +113,7 @@ def _get_files_to_download(path, c, debug=False):
     with open(meta_filename, "r") as fh:
         download_requests = yaml.load(fh, Loader=yaml.FullLoader)
 
-    files_to_download = []
+    files = []
     if len(download_requests) > 0:
         if debug:
             print("Status on current data requests:")
@@ -123,9 +123,12 @@ def _get_files_to_download(path, c, debug=False):
             if debug:
                 print(" {}:\n\t{} ({})".format(file_path, status, request_id))
 
-            if status == "completed":
-                files_to_download.append(file_path)
-    return files_to_download
+            if with_status is not None:
+                if status == with_status or status in with_status:
+                    files.append(file_path)
+            else:
+                files.append(file_path)
+    return files
 
 
 def _data_valid(file_path, query_hash):


### PR DESCRIPTION
Adds a flag to the CLI `--retry-rate` which causes the download utility to sleep (for the number of minutes given) before retrying download of any files not yet completed