### PR TITLE
Remove expired era5 download requests

### DIFF
--- a/lagtraj/domain/download.py
+++ b/lagtraj/domain/download.py
@@ -1,6 +1,7 @@
 import dateutil.parser
 from pathlib import Path
 from time import sleep
+import datetime
 
 from .sources import era5
 from .. import DEFAULT_ROOT_DATA_PATH
@@ -135,7 +136,9 @@ def _run_cli(timedomain_lookup="by_arguments"):
             if download_complete(args.data_path, domain_name=domain):
                 break
             else:
-                print(f"Sleeping {args.retry_rate}min...")
+                t_now = datetime.datetime.now()
+                t_now_s = t_now.strftime("%Y%m%dT%H%M")
+                print(f"{t_now_s}: Sleeping {args.retry_rate}min...")
                 sleep(args.retry_rate * 60.0)
                 print("Retrying download")
     else:

--- a/lagtraj/domain/sources/era5/download.py
+++ b/lagtraj/domain/sources/era5/download.py
@@ -23,9 +23,11 @@ def download_data(
     path, t_start, t_end, bbox, latlon_sampling, overwrite_existing=False
 ):
 
-    dl_queries = list(_build_queries(
-        t_start=t_start, t_end=t_end, bbox=bbox, latlon_sampling=latlon_sampling
-    ))
+    dl_queries = list(
+        _build_queries(
+            t_start=t_start, t_end=t_end, bbox=bbox, latlon_sampling=latlon_sampling
+        )
+    )
 
     c = RequestFetchCDSClient()
 
@@ -95,9 +97,11 @@ def download_data(
                 _fingerprint_downloaded_file(query_hash=query_hash, file_path=file_path)
             except requests.exceptions.HTTPError as ex:
                 if ex.response.status_code == 404:
-                    print(f"Request {request_details['request_id']} wasn't found"
-                          " on the CDS backend, it has probably expired."
-                          " Re-requesting...")
+                    print(
+                        f"Request {request_details['request_id']} wasn't found"
+                        " on the CDS backend, it has probably expired."
+                        " Re-requesting..."
+                    )
                     # delete the stored request and re-request the data
                     query_kwargs = dict(dl_queries)[Path(file_path).name]
                     request_id = c.queue_data_request(

--- a/lagtraj/domain/sources/era5/download.py
+++ b/lagtraj/domain/sources/era5/download.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import netCDF4
 import yaml
+import requests
 
 from .... import utils
 from .cdsapi_request import RequestFetchCDSClient
@@ -89,10 +90,14 @@ def download_data(
             query_hash = request_details["query_hash"]
 
             Path(file_path).parent.mkdir(exist_ok=True, parents=True)
-            c.download_data_by_request(request_id=request_id, target=file_path)
-            _fingerprint_downloaded_file(query_hash=query_hash, file_path=file_path)
-
-            del download_requests[file_path]
+            try:
+                c.download_data_by_request(request_id=request_id, target=file_path)
+                _fingerprint_downloaded_file(query_hash=query_hash, file_path=file_path)
+                del download_requests[file_path]
+            except requests.exceptions.HTTPError as e:
+                import ipdb
+                ipdb.set_trace()
+                a = 5
 
     # save download requets again now we've downloaded the files that were
     # ready

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+from lagtraj.conversion import build_conversion_data_path
+
+
+def test_convert_forcing_to_pkt_format(ds_forcing_linear_trajectory):
+    ds_forcing = ds_forcing_linear_trajectory
+    pass

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,9 +1,0 @@
-import pytest
-
-
-from lagtraj.conversion import build_conversion_data_path
-
-
-def test_convert_forcing_to_pkt_format(ds_forcing_linear_trajectory):
-    ds_forcing = ds_forcing_linear_trajectory
-    pass


### PR DESCRIPTION
If too long time has passed between a data request being made, the data becoming available and then the download is actually initiated the data for download sometimes expires on the CDS backend and is no longer available. This pull-request handles this situation by deleting the local data request id and re-submitting the data request.

Closes https://github.com/EUREC4A-UK/lagtraj/issues/38