### PR TITLE
Bugfix for level calculation

### DIFF
--- a/lagtraj/forcings/utils/levels.py
+++ b/lagtraj/forcings/utils/levels.py
@@ -17,9 +17,9 @@ ForcingLevelsDefinition = namedtuple(
 
 def make_levels(method, n_levels, z_top, dz_min=None):
     if method == "linear":
-        levels = _make_exponential_levels(dz_min, z_top, n_levels)
-    elif method == "exponential":
         levels = _make_linear_levels(z_top, n_levels)
+    elif method == "exponential":
+        levels = _make_exponential_levels(dz_min, z_top, n_levels)
     else:
         raise Exception("Unknown strategy for making levels")
     return xr.DataArray(


### PR DESCRIPTION
Previously the linear and exponential methods were swapped around so that when requesting "exponential" levels actually linear levels were computed.