### PR TITLE
ensure that ERA5 dataset has `data_source` attr

### DIFF
--- a/lagtraj/domain/sources/era5/load.py
+++ b/lagtraj/domain/sources/era5/load.py
@@ -185,7 +185,9 @@ class ERA5DataSet(object):
                     }
             datasets_slices.append(ds_v_slice)
 
-        return xr.merge(datasets_slices, compat="override").load()
+        ds_ = xr.merge(datasets_slices, compat="override").load()
+        ds_.attrs["data_source"] = "era5"
+        return ds_
 
     def interp(self, kwargs, method="linear", **interp_to):
         """
@@ -257,7 +259,9 @@ class ERA5DataSet(object):
         extra_dims = list(set(interp_to.keys()).difference(ds_slice.dims))
         for d in extra_dims:
             del interp_to[d]
-        return ds_slice.interp(**interp_to, kwargs=kwargs, method=method).load()
+        ds_ = ds_slice.interp(**interp_to, kwargs=kwargs, method=method).load()
+        ds_.attrs["data_source"] = "era5"
+        return ds_
 
 
 def _load_naive(data_path):

--- a/lagtraj/forcings/profile_calculation.py
+++ b/lagtraj/forcings/profile_calculation.py
@@ -157,7 +157,6 @@ def _construct_subdomain(
     # units will be requested whe calculating mean and local values
     ds_subdomain["mask"].attrs["units"] = "(0 - 1)"
     ds_subdomain = ds_subdomain.where(ds_subdomain.mask, other=np.nan)
-    ds_subdomain.attrs["data_source"] = ds_domain.attrs.get("data_source")
 
     # TODO: this interpolates all domain variables to height levels, but we
     # should only interpolate the variables necessary to produce the requested

--- a/lagtraj/trajectory/extrapolation.py
+++ b/lagtraj/trajectory/extrapolation.py
@@ -78,9 +78,6 @@ def extrapolate_using_domain_data(
     ds_column_interpolated = _extract_column_at_time(
         t=t0, lat=lat, lon=lon, method=time_space_interpolation, ds_domain=ds_domain
     )
-    # to be able to interpolate to height levels and produce auxiliary
-    # variables later we need to know where this data originated
-    ds_column_interpolated.attrs["data_source"] = ds_domain.attrs.get("data_source")
 
     lat_start, lon_start = lat, lon
     u_start, v_start = estimate_horizontal_velocities(


### PR DESCRIPTION
The `data_source` attr is required to be able to correctly do interpolation and calculation of auxiliary variables