### PR TITLE
Check local input defns when using bundled ones

### DIFF
--- a/lagtraj/input_definitions/examples.py
+++ b/lagtraj/input_definitions/examples.py
@@ -15,16 +15,14 @@ class LagtrajExampleDoesNotExist(Exception):
     pass
 
 
-def attempt_read(input_name, input_type):
+def get_path(input_name, input_type, parse_yaml=True):
     input_type = DATA_TYPE_PLURAL.get(input_type, input_type)
 
     file_path = P_ROOT / input_type / (input_name + ".yaml")
     if not file_path.exists():
         raise LagtrajExampleDoesNotExist
 
-    with open(file_path) as fh:
-        defn = yaml.load(fh, Loader=yaml.FullLoader)
-        return defn
+    return file_path
 
 
 def get_available(input_types="all"):

--- a/lagtraj/input_definitions/load.py
+++ b/lagtraj/input_definitions/load.py
@@ -1,6 +1,10 @@
 import yaml
 import sys
 from pathlib import Path
+import difflib
+import tempfile
+import shutil
+
 
 from . import validate_input, build_input_definition_path, examples as input_examples
 from .. import DATA_TYPE_PLURAL
@@ -24,26 +28,16 @@ data
 
 
 def load_definition(input_name, input_type, root_data_path, required_fields):
-    if input_name.startswith("lagtraj://"):
+    params = None
+    input_path = None
+    requesting_lagtraj_bundled_input = input_name.startswith("lagtraj://")
+
+    if requesting_lagtraj_bundled_input:
         try:
             input_name = input_name.replace("lagtraj://", "")
-
-            params = input_examples.attempt_read(
+            input_path = input_examples.get_path(
                 input_name=input_name, input_type=input_type
             )
-
-            input_local_path = build_input_definition_path(
-                root_data_path=root_data_path,
-                input_name=input_name,
-                input_type=input_type,
-            )
-
-            if not input_local_path.exists():
-                input_local_path.parent.mkdir(exist_ok=True, parents=True)
-                with open(input_local_path, "w") as fh:
-                    fh.write(yaml.dump(params))
-
-            input_name = input_name
         except input_examples.LagtrajExampleDoesNotExist:
             input_type_plural = DATA_TYPE_PLURAL[input_type]
             print(
@@ -59,8 +53,8 @@ def load_definition(input_name, input_type, root_data_path, required_fields):
     else:
         if input_name.endswith(".yaml") or input_name.endswith(".yml"):
             # assume we've been passed a full path
-            input_local_path = Path(input_name)
-            if not input_local_path.exists():
+            input_path = Path(input_name)
+            if not input_path.exists():
                 raise Exception(
                     "You provided an absolute path to an input"
                     " yaml file, but that file doesn't appear"
@@ -71,8 +65,8 @@ def load_definition(input_name, input_type, root_data_path, required_fields):
             # structure
             input_type_plural = DATA_TYPE_PLURAL[input_type]
             if not (
-                input_local_path.parent.parent.name == "data"
-                and input_local_path.parent.name == input_type_plural
+                input_path.parent.parent.name == "data"
+                and input_path.parent.name == input_type_plural
             ):
                 lagtraj_input_examples = list(
                     get_available_input_examples(input_types=[input_type])
@@ -92,25 +86,68 @@ def load_definition(input_name, input_type, root_data_path, required_fields):
                     "The input files are then copied over to the data directory."
                 )
         else:
-            input_local_path = build_input_definition_path(
+            input_path = build_input_definition_path(
                 root_data_path=root_data_path,
                 input_name=input_name,
                 input_type=input_type,
             )
-            if not input_local_path.exists():
+            if not input_path.exists():
                 input_type_plural = DATA_TYPE_PLURAL[input_type]
                 raise Exception(
                     f"The requested {input_type} ({input_name}) wasn't found. "
                     f"To use a {input_type} with this name please define its "
-                    f"parameters {input_local_path}\n"
+                    f"parameters {input_path}\n"
                     "(or run `python -m lagtraj.input_definitions.examples` all available with"
                     "to see the ones currently bundled with lagtraj"
                 )
             print()
-        with open(input_local_path) as fh:
-            params = yaml.load(fh, Loader=yaml.FullLoader)
+
+    with open(input_path) as fh:
+        params = yaml.load(fh, Loader=yaml.FullLoader)
 
     validate_input(input_params=params, required_fields=required_fields)
     params["name"] = input_name
+
+    if requesting_lagtraj_bundled_input:
+        # when the user requests a lagtraj-bundled input definition we copy it
+        # to their local `data/` directory, but we need to check if there's
+        # already a file there and whether that has any modifications
+
+        input_local_path = build_input_definition_path(
+            root_data_path=root_data_path, input_name=input_name, input_type=input_type,
+        )
+
+        if not input_local_path.exists():
+            # if it doesn't exist we can just copy across no problem
+            input_local_path.parent.mkdir(exist_ok=True, parents=True)
+            shutil.copy(input_path, input_local_path)
+        else:
+            # otherwise we need to check the contents
+
+            input_raw = open(input_path).read().splitlines()
+            input_local_raw = open(input_local_path).read().splitlines()
+
+            param_diff = list(
+                difflib.unified_diff(
+                    a=input_raw,
+                    b=input_local_raw,
+                    fromfile="lagtraj://",
+                    tofile="local",
+                    lineterm="",
+                )
+            )
+            if len(param_diff) != 0:
+                print("\n".join(param_diff))
+                print()
+                raise Exception(
+                    f"Your local of the `{input_name}` {input_type} "
+                    f"input-definition in `{input_local_path}` "
+                    "is different to what is included with "
+                    "lagtraj (see the differences above). Either you can "
+                    "use your local copy directly (by removing the `lagtraj://` "
+                    "part in the command you just issued) or delete your "
+                    "local copy and we'll copy over what's included with "
+                    "lagtraj."
+                )
 
     return params


### PR DESCRIPTION
When a user tries to use an input-definition by default we copy that
input definition to the user's local `data/` directory. We now check
if there is an existing file there and compare these, if there are any
differences we halt the operation and ask the user to either delete the
file or request to use the local file explicitly instead.

Closes https://github.com/EUREC4A-UK/lagtraj/issues/29