### PR TITLE
Included input defns should all use lagtraj://

### DIFF
--- a/input_examples/forcings/eurec4a_20191209_12_eul.yaml
+++ b/input_examples/forcings/eurec4a_20191209_12_eul.yaml
@@ -1,6 +1,6 @@
-trajectory      : eurec4a_20191209_12_eul
-version         : 1.0.0
-domain          : eurec4a_circle_eul
+trajectory      : lagtraj://eurec4a_20191209_12_eul
+version         : 1.0.1
+domain          : lagtraj://eurec4a_circle
 gradient_method : regression
 advection_velocity_sampling_method : domain_mean
 averaging_width : 2.0

--- a/input_examples/forcings/eurec4a_20191209_12_lag.yaml
+++ b/input_examples/forcings/eurec4a_20191209_12_lag.yaml
@@ -1,6 +1,6 @@
-trajectory      : eurec4a_20191209_12_lag
-version         : 1.0.0
-domain          : eurec4a_circle_eul
+trajectory      : lagtraj://eurec4a_20191209_12_lag
+version         : 1.0.1
+domain          : lagtraj://eurec4a_circle
 gradient_method : regression
 advection_velocity_sampling_method : domain_mean
 averaging_width : 2.0

--- a/input_examples/forcings/eurec4a_20200202_12_lag.yaml
+++ b/input_examples/forcings/eurec4a_20200202_12_lag.yaml
@@ -1,6 +1,6 @@
-trajectory      : eurec4a_20200202_12_lag
-version         : 1.0.0
-domain          : eurec4a_circle_eul
+trajectory      : lagtraj://eurec4a_20200202_12_lag
+version         : 1.0.1
+domain          : lagtraj://eurec4a_circle
 gradient_method : regression
 advection_velocity_sampling_method : domain_mean
 averaging_width : 2.0

--- a/input_examples/forcings/eurec4a_20200202_12_lag_short.yaml
+++ b/input_examples/forcings/eurec4a_20200202_12_lag_short.yaml
@@ -1,6 +1,6 @@
-trajectory      : eurec4a_20200202_12_lag_short
-version         : 1.0.0
-domain          : eurec4a_circle_eul
+trajectory      : lagtraj://eurec4a_20200202_12_lag_short
+version         : 1.0.1
+domain          : lagtraj://eurec4a_circle
 gradient_method : regression
 advection_velocity_sampling_method : domain_mean
 averaging_width : 2.0

--- a/input_examples/forcings/eurec4a_20200205_15_lag.yaml
+++ b/input_examples/forcings/eurec4a_20200205_15_lag.yaml
@@ -1,6 +1,6 @@
-trajectory      : eurec4a_20200205_15_lag
-version         : 1.0.0
-domain          : eurec4a_circle_eul
+trajectory      : lagtraj://eurec4a_20200205_15_lag
+version         : 1.0.1
+domain          : lagtraj://eurec4a_circle
 gradient_method : regression
 advection_velocity_sampling_method : domain_mean
 averaging_width : 2.0

--- a/input_examples/forcings/eurec4a_campaign_eulerian.yaml
+++ b/input_examples/forcings/eurec4a_campaign_eulerian.yaml
@@ -1,6 +1,6 @@
-trajectory      : eurec4a_campaign_eulerian
-version         : 1.0.0
-domain          : eurec4a_circle_domain
+trajectory      : lagtraj://eurec4a_campaign_eulerian
+version         : 1.0.1
+domain          : lagtraj://eurec4a_circle
 gradient_method : regression
 advection_velocity_sampling_method : domain_mean
 averaging_width : 2.0

--- a/tests/test_input_definition_examples.py
+++ b/tests/test_input_definition_examples.py
@@ -77,12 +77,14 @@ def test_load_example(input_example):
     for k, v in params.items():
         if isinstance(v, str) and k in INPUT_TYPES.keys():
             if not v.startswith("lagtraj://"):
-                raise Exception("All input definitions which are included with "
-                                "lagtraj should only refer to other inputs "
-                                "included with lagtraj (i.e. should have the "
-                                f"`lagtraj://` prefix). The `{input_name}` "
-                                f"{input_type} input definition returns to the "
-                                f"`{v}` {k}")
+                raise Exception(
+                    "All input definitions which are included with "
+                    "lagtraj should only refer to other inputs "
+                    "included with lagtraj (i.e. should have the "
+                    f"`lagtraj://` prefix). The `{input_name}` "
+                    f"{input_type} input definition returns to the "
+                    f"`{v}` {k}"
+                )
             else:
                 try:
                     lagtraj.input_definitions.examples.attempt_read(

--- a/tests/test_input_definition_examples.py
+++ b/tests/test_input_definition_examples.py
@@ -51,6 +51,10 @@ def test_load_example(input_example):
     input_type_plural = input_example[:i]
     input_name = f"lagtraj://{input_example[i + 1 :]}"
 
+    if input_type_plural == "forcings_conversion":
+        # TODO: implement tests for the forcing conversions bundled with lagtraj
+        return
+
     input_type = None
     for k, v in DATA_TYPE_PLURAL.items():
         if v == input_type_plural:
@@ -71,18 +75,25 @@ def test_load_example(input_example):
     # referring to another input-definition, so we should check here that it
     # exists
     for k, v in params.items():
-        if isinstance(v, str) and v.startswith("lagtraj://"):
-            try:
-                lagtraj.input_definitions.examples.attempt_read(
-                    input_name=v, input_type=k
-                )
-            except lagtraj.input_definitions.examples.LagtrajExampleDoesNotExist:
-                raise
-                raise Exception(
-                    f"The input-definition `lagtraj://{input_name}` "
-                    f"refers to the `{v}` {k} input definition "
-                    "which doesn't exist!"
-                )
+        if isinstance(v, str) and k in INPUT_TYPES.keys():
+            if not v.startswith("lagtraj://"):
+                raise Exception("All input definitions which are included with "
+                                "lagtraj should only refer to other inputs "
+                                "included with lagtraj (i.e. should have the "
+                                f"`lagtraj://` prefix). The `{input_name}` "
+                                f"{input_type} input definition returns to the "
+                                f"`{v}` {k}")
+            else:
+                try:
+                    lagtraj.input_definitions.examples.attempt_read(
+                        input_name=v, input_type=k
+                    )
+                except lagtraj.input_definitions.examples.LagtrajExampleDoesNotExist:
+                    raise Exception(
+                        f"The input-definition `lagtraj://{input_name}` "
+                        f"refers to the `{v}` {k} input definition "
+                        "which doesn't exist!"
+                    )
 
     if input_defn["version"] == "unversioned":
         raise Exception(


### PR DESCRIPTION
Previously some input definitions for forcings referred to domains by
name without the `lagtraj://` prefix, which meant the fact they were
referring to a domain definition that didn't exist wasn't caught.

With this commit input definitions can only be included in the
repository if they refer to domains, trajectories etc with the
`lagtraj://` prefix