### PR TITLE
Fixes for versioning and output attributes

### DIFF
--- a/lagtraj/domain/__init__.py
+++ b/lagtraj/domain/__init__.py
@@ -6,6 +6,7 @@ from .sources import (
     interpolate_to_pressure_levels,
 )  # noqa
 from .sources import calc_auxiliary_variable  # noqa
+from ..input_definitions.examples import LAGTRAJ_EXAMPLES_PATH_PREFIX
 
 LatLonBoundingBox = namedtuple(
     "LatLonBoundingBox", ["lat_min", "lat_max", "lon_min", "lon_max"]
@@ -26,6 +27,11 @@ INPUT_REQUIRED_FIELDS = dict(
 
 
 def build_domain_data_path(root_data_path, domain_name):
+    # we need to strip the `lagtraj://` prefix before we construct the path
+    # since the data is stored locally
+    if domain_name.startswith(LAGTRAJ_EXAMPLES_PATH_PREFIX):
+        domain_name = domain_name[len(LAGTRAJ_EXAMPLES_PATH_PREFIX) :]
+
     return build_data_path(root_data_path=root_data_path, data_type="domain") / (
         f"{domain_name}_data"
     )

--- a/lagtraj/domain/load.py
+++ b/lagtraj/domain/load.py
@@ -1,6 +1,7 @@
 from ..input_definitions import load
 from . import INPUT_REQUIRED_FIELDS, build_domain_data_path
 from .sources import era5
+from ..input_definitions.examples import LAGTRAJ_EXAMPLES_PATH_PREFIX
 
 
 def load_definition(domain_name, data_path):
@@ -38,9 +39,13 @@ def load_data(root_data_path, name):
 
     if ds.version != domain_def["version"]:
         raise Exception(
-            "The domain data in `{data_path}` doesn't match the version"
-            " stored in the data definition for `{name}`. Please delete"
+            f"The domain data in `{data_path}` doesn't match the version"
+            f" stored in the data definition for `{name}` (`{ds.version}` "
+            f"!= `{domain_def['version']}`). Please delete"
             " the domain data and re-download."
         )
+
+    # need to keep track of the name of this domain dataset
+    ds.attrs["name"] = name
 
     return ds

--- a/lagtraj/domain/sources/__init__.py
+++ b/lagtraj/domain/sources/__init__.py
@@ -5,6 +5,10 @@ correct functions depending on the data source a given dataset originated from.
 import xarray as xr
 
 
+class MissingDomainData(Exception):
+    pass
+
+
 from .era5.interpolation import interpolate_to_height_levels as era5_hl_interp
 from .era5.interpolation import interpolate_to_pressure_levels as era5_pl_interp
 from .era5.aux_variables import calc_variable as era5_calc

--- a/lagtraj/domain/sources/era5/utils.py
+++ b/lagtraj/domain/sources/era5/utils.py
@@ -128,12 +128,12 @@ def calculate_heights_and_pressures(ds):
 def add_era5_global_attributes(ds):
     """Adds global attributes to datasets"""
     global_attrs = {
-        r"Conventions": r"CF-1.7",
-        r"Contact": r"l.c.denby[at]leeds[dot]ac[dot again]uk s.boeing[at]leeds[dot]ac[dot again]uk",
-        r"ERA5 reference": r"Hersbach, H., Bell, B., Berrisford, P., Hirahara, S., Horányi, A., Muñoz‐Sabater, J., ... & Simmons, A. (2020). The ERA5 global reanalysis. Quarterly Journal of the Royal Meteorological Society.",
-        r"Created": datetime.datetime.now().isoformat(),
-        r"Created with": r"https://github.com/EUREC4A-UK/lagtraj",
-        r"Note": "Contains modified Copernicus Service information ",
+        r"conventions": r"CF-1.7",
+        r"contact": r"l.c.denby[at]leeds[dot]ac[dot again]uk s.boeing[at]leeds[dot]ac[dot again]uk",
+        r"era5_reference": r"Hersbach, H., Bell, B., Berrisford, P., Hirahara, S., Horányi, A., Muñoz‐Sabater, J., ... & Simmons, A. (2020). The ERA5 global reanalysis. Quarterly Journal of the Royal Meteorological Society.",
+        r"created": datetime.datetime.now().isoformat(),
+        r"created_with": r"https://github.com/EUREC4A-UK/lagtraj",
+        r"note": "Contains modified Copernicus Service information ",
     }
     for attribute in global_attrs:
         ds.attrs[attribute] = global_attrs[attribute]

--- a/lagtraj/forcings/__init__.py
+++ b/lagtraj/forcings/__init__.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from ..utils.interpolation.levels import ForcingLevelsDefinition  # noqa
 from .profile_calculation import ForcingSamplingDefinition  # noqa
 from .. import build_data_path
+from ..input_definitions.examples import LAGTRAJ_EXAMPLES_PATH_PREFIX
 
 
 INPUT_REQUIRED_FIELDS = dict(
@@ -26,6 +27,12 @@ ForcingDefinition = namedtuple(
 
 
 def build_forcing_data_path(root_data_path, forcing_name):
+    # we need to strip the `lagtraj://` prefix before we construct the path
+    # since the data is stored locally
+    if forcing_name.startswith(LAGTRAJ_EXAMPLES_PATH_PREFIX):
+        forcing_name = forcing_name[len(LAGTRAJ_EXAMPLES_PATH_PREFIX) :]
+
+    filename = f"{forcing_name}.nc"
     return build_data_path(root_data_path=root_data_path, data_type="forcing") / (
         forcing_name + ".nc"
     )

--- a/lagtraj/forcings/create.py
+++ b/lagtraj/forcings/create.py
@@ -120,9 +120,10 @@ def main():
         root_data_path=args.data_path, forcing_name=args.forcing
     )
 
-    ds_domain = load_domain_data(
-        root_data_path=args.data_path, name=forcing_defn.domain
-    )
+    with optional_debugging(args.debug):
+        ds_domain = load_domain_data(
+            root_data_path=args.data_path, name=forcing_defn.domain
+        )
     try:
         ds_trajectory = load_trajectory_data(
             root_data_path=args.data_path, name=forcing_defn.trajectory

--- a/lagtraj/input_definitions/load.py
+++ b/lagtraj/input_definitions/load.py
@@ -130,6 +130,11 @@ def load_definition(input_name, input_type, root_data_path, required_fields):
         # to their local `data/` directory, but we need to check if there's
         # already a file there and whether that has any modifications
 
+        # we need to strip the `lagtraj://` prefix before we construct the path
+        # since the data is stored locally
+        if input_name.startswith(LAGTRAJ_EXAMPLES_PATH_PREFIX):
+            input_name = input_name[len(LAGTRAJ_EXAMPLES_PATH_PREFIX) :]
+
         input_local_path = build_input_definition_path(
             root_data_path=root_data_path, input_name=input_name, input_type=input_type,
         )

--- a/lagtraj/trajectory/__init__.py
+++ b/lagtraj/trajectory/__init__.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 from .. import build_data_path as build_data_path_global
 from ..input_definitions import InvalidInputDefinition
+from ..input_definitions.examples import LAGTRAJ_EXAMPLES_PATH_PREFIX
 
 
 TrajectoryOrigin = namedtuple("TrajectoryOrigin", ["lat", "lon", "datetime"])
@@ -102,6 +103,11 @@ INPUT_REQUIRED_FIELDS = {
 
 
 def build_data_path(root_data_path, trajectory_name):
+    # we need to strip the `lagtraj://` prefix before we construct the path
+    # since the data is stored locally
+    if trajectory_name.startswith(LAGTRAJ_EXAMPLES_PATH_PREFIX):
+        trajectory_name = trajectory_name[len(LAGTRAJ_EXAMPLES_PATH_PREFIX) :]
+
     data_path = build_data_path_global(
         root_data_path=root_data_path, data_type="trajectory"
     )

--- a/lagtraj/trajectory/create.py
+++ b/lagtraj/trajectory/create.py
@@ -54,6 +54,11 @@ def create_trajectory(origin, trajectory_type, da_times, **kwargs):
         )
     else:
         raise NotImplementedError(f"`{trajectory_type}` trajectory type not available")
+
+    # before we make the attributes rename domain so that it isn't called
+    # `ds_domain` in the attributes
+    if "ds_domain" in kwargs:
+        kwargs["domain"] = kwargs.pop("ds_domain")
     ds_traj.attrs.update(
         create_attributes_dictionary(trajectory_type=trajectory_type, **kwargs)
     )

--- a/lagtraj/trajectory/load.py
+++ b/lagtraj/trajectory/load.py
@@ -31,7 +31,7 @@ def load_definition(root_data_path, name):
     )
 
     extra_kwargs = {}
-    if "u_vel" in params or "v_vel" in params:
+    if params.get("u_vel") is not None or params.get("v_vel") is not None:
         if not ("u_vel" in params and "v_vel" in params):
             raise Exception(
                 "Both `u_vel` and `v_vel` should be defined when"
@@ -39,15 +39,15 @@ def load_definition(root_data_path, name):
             )
         extra_kwargs["U"] = (params["u_vel"], params["v_vel"])
 
-    if "velocity_method" in params:
+    if params.get("velocity_method") is not None:
         extra_kwargs["velocity_method"] = params["velocity_method"]
 
-    if "velocity_method_height" in params:
+    if params.get("velocity_method_height") is not None:
         extra_kwargs["velocity_method_kwargs"] = dict(
             height=params["velocity_method_height"]
         )
 
-    if "velocity_method_pressure" in params:
+    if params.get("velocity_method_pressure") is not None:
         extra_kwargs["velocity_method_kwargs"] = dict(
             pressure=params["velocity_method_pressure"]
         )


### PR DESCRIPTION
Handles some issues that came up:

- when keeping the `lagtraj://` for input definitions (so that this name
  can go in the output attributes) we need to ensure we strip this
  prefix before constructing the local datapath used for storing the
  output

- by default the input definition returns a value for all possible
  parameters, but if a specific parameter isn't used the value is set to
  `None`. This means we should check for `None` as well as checking for
  existance

- A few typos were caught (like not stripping newline in the VERSION
  file for domains)