### PR TITLE
Ensure domain data creation time is fixed

### DIFF
--- a/lagtraj/domain/sources/era5/load.py
+++ b/lagtraj/domain/sources/era5/load.py
@@ -9,6 +9,7 @@ import datetime
 from . import FILENAME_FORMAT, VERSION_FILENAME
 from .utils import add_era5_global_attributes
 from .. import MissingDomainData
+from ....utils.units import round_time
 
 MODEL_RUN_TYPES = ["an", "fc"]  # analysis and forecast runs
 LEVEL_TYPES = ["model", "single"]  # need model and surface data
@@ -82,7 +83,10 @@ def _calc_creation_timestamp(data_path):
 
             creation_times += [fn.stat().st_ctime for fn in files]
 
-    return datetime.datetime.fromtimestamp(min(creation_times))
+    t = datetime.datetime.fromtimestamp(min(creation_times))
+
+    # round to nearest second
+    return round_time(t, num_seconds=1)
 
 
 class ERA5DataSet(object):

--- a/lagtraj/domain/sources/era5/utils.py
+++ b/lagtraj/domain/sources/era5/utils.py
@@ -125,13 +125,13 @@ def calculate_heights_and_pressures(ds):
     return xr.concat(datasets, dim="time").squeeze()
 
 
-def add_era5_global_attributes(ds):
+def add_era5_global_attributes(ds, creation_datetime):
     """Adds global attributes to datasets"""
     global_attrs = {
         r"conventions": r"CF-1.7",
         r"contact": r"l.c.denby[at]leeds[dot]ac[dot again]uk s.boeing[at]leeds[dot]ac[dot again]uk",
         r"era5_reference": r"Hersbach, H., Bell, B., Berrisford, P., Hirahara, S., Horányi, A., Muñoz‐Sabater, J., ... & Simmons, A. (2020). The ERA5 global reanalysis. Quarterly Journal of the Royal Meteorological Society.",
-        r"created": datetime.datetime.now().isoformat(),
+        r"created": creation_datetime.isoformat(),
         r"created_with": r"https://github.com/EUREC4A-UK/lagtraj",
         r"note": "Contains modified Copernicus Service information ",
     }

--- a/lagtraj/utils/units.py
+++ b/lagtraj/utils/units.py
@@ -1,3 +1,6 @@
+import datetime
+
+
 def fix_units(ds):
     """Changes units of data to make them compatible with the cf-checker"""
     units_dict = {
@@ -12,3 +15,17 @@ def fix_units(ds):
             these_units = ds[variable].units
             if these_units in units_dict:
                 ds[variable].attrs["units"] = units_dict[these_units]
+
+
+def round_time(dt=None, num_seconds=60):
+    """Round a datetime object to any time lapse in seconds
+    dt : datetime.datetime object, default now.
+    num_seconds : Closest number of seconds to round to, default 1 minute.
+
+    based off https://stackoverflow.com/a/10854034
+    """
+    if dt is None:
+        dt = datetime.datetime.now()
+    seconds = (dt.replace(tzinfo=None) - dt.min).seconds
+    rounding = (seconds + num_seconds / 2) // num_seconds * num_seconds
+    return dt + datetime.timedelta(0, rounding - seconds, -dt.microsecond)


### PR DESCRIPTION
Previously domain data creation time was set to current time every time
domain data is loaded. This doesn't work when attempting to apply
conversion to an existing forcing file since the attributes of the
loaded forcing file don't match the attributes derived a conversion time
(since conversion might happen as a separate and later step). The
"creation time" for domain data is now set to the creation time for the
first downloaded file. This ensures that the creation time doesn't
change as domain data is downloaded and only changes if all domain data
is deleted and re-downloaded.