### PR TITLE
Forces domain to be specified on all trajectories

### DIFF
--- a/lagtraj/trajectory/__init__.py
+++ b/lagtraj/trajectory/__init__.py
@@ -27,7 +27,7 @@ TrajectoryDefinition = namedtuple(
 INPUT_REQUIRED_FIELDS = {
     "trajectory_type": ["linear", "eulerian", "lagrangian"],
     # domain should only be given when creating a lagrangian trajectory
-    "domain": dict(requires=dict(trajectory_type="lagrangian"), choices=str),
+    "domain": str,
     "lat_origin": float,
     "lon_origin": float,
     "datetime_origin": isodate.parse_datetime,

--- a/lagtraj/utils/validation.py
+++ b/lagtraj/utils/validation.py
@@ -21,9 +21,7 @@ def validate_trajectory(ds_traj):
             " fields: {}".format(", ".join(missing_fields))
         )
 
-    required_attrs = ["name", "trajectory_type"]
-    if ds_traj.attrs.get("trajectory_type") != "linear":
-        required_attrs += ["domain_name"]
+    required_attrs = ["name", "trajectory_type", "domain"]
     missing_attrs = list(filter(lambda f: f not in ds_traj.attrs, required_attrs))
 
     if len(missing_attrs) > 0:


### PR DESCRIPTION
Here is a quick fix for #112. However, this requires the domain data to always be available: we may want to have more flexibility on the times/do time interpolation in future.