### PR TITLE
Fix inconsistency for Eulerian traj without domain

### DIFF
--- a/input_examples/trajectories/eurec4a_20191209_12_eul.yaml
+++ b/input_examples/trajectories/eurec4a_20191209_12_eul.yaml
@@ -1,8 +1,8 @@
 trajectory_type    : eulerian
-version            : 1.0.1
+version            : 1.0.2
 lat_origin         : 13.3
 lon_origin         : -57.717
 datetime_origin    : 2020-01-01T12:00
 forward_duration   : PT24H
 backward_duration  : PT24H
-timestep           : domain_data  # or for example PT1H
+timestep           : PT1H

--- a/input_examples/trajectories/eurec4a_campaign_eulerian.yaml
+++ b/input_examples/trajectories/eurec4a_campaign_eulerian.yaml
@@ -1,4 +1,5 @@
 trajectory_type : eulerian
+domain          : lagtraj://eurec4a_circle
 version         : 1.0.1
 lat_origin      : 13.3
 lon_origin      : -57.717

--- a/lagtraj/input_definitions/__init__.py
+++ b/lagtraj/input_definitions/__init__.py
@@ -48,6 +48,20 @@ def validate_input(input_params, required_fields):
                 requirements = f_option["requires"]
                 satisfied_requirements = {}
                 for f_name_reqd, f_option_reqd in requirements.items():
+                    # special flag for making a requirement that another
+                    # parameter is set
+                    if f_option_reqd == "__is_set__":
+                        f_reqd_value = input_params.get(f_name_reqd)
+                        f_value = input_params.get(f_name)
+                        if f_reqd_value is not None:
+                            satisfied_requirements[f_name_reqd] = f_value
+                            continue
+                        else:
+                            raise InvalidInputDefinition(
+                                f"For `{f_name}` == `{f_value}` the `{f_name_reqd}`"
+                                " must be set"
+                            )
+
                     try:
                         res = _check_field(f_name=f_name_reqd, f_option=f_option_reqd)
                         satisfied_requirements[f_name_reqd] = res

--- a/lagtraj/trajectory/__init__.py
+++ b/lagtraj/trajectory/__init__.py
@@ -26,13 +26,24 @@ TrajectoryDefinition = namedtuple(
 
 INPUT_REQUIRED_FIELDS = {
     "trajectory_type": ["linear", "eulerian", "lagrangian"],
-    # domain should only be given when creating a lagrangian trajectory
-    "domain": dict(requires=dict(trajectory_type="lagrangian"), choices=str),
+    # domain should only be given when creating a lagrangian trajectory or if
+    # we're trying to get the timestep from the domain data. In both cases the
+    # domain should be a string
+    "domain": [
+        dict(requires=dict(trajectory_type="lagrangian"), choices=str),
+        dict(requires=dict(timestep="domain_data"), choices=str),
+        None,
+    ],
     "lat_origin": float,
     "lon_origin": float,
     "datetime_origin": isodate.parse_datetime,
     "forward_duration|backward_duration": isodate.parse_duration,
-    "timestep": ("domain_data", isodate.parse_duration),
+    # if the domain is given we can use domain data for the timestep, otherwise
+    # the timestep should be a parsable duration string
+    "timestep": (
+        dict(requires=dict(domain="__is_set__"), choices=["domain_data"],),
+        isodate.parse_duration,
+    ),
     # only linear trajectories need to have their velocity prescribed
     "u_vel": dict(requires=dict(trajectory_type="linear"), choices=float),
     "v_vel": dict(requires=dict(trajectory_type="linear"), choices=float),

--- a/lagtraj/utils/validation.py
+++ b/lagtraj/utils/validation.py
@@ -22,8 +22,13 @@ def validate_trajectory(ds_traj):
         )
 
     required_attrs = ["name", "trajectory_type"]
-    if ds_traj.attrs.get("trajectory_type") != "linear":
-        required_attrs += ["domain_name"]
+
+    trajectory_type = ds_traj.attrs.get("trajectory_type")
+    if trajectory_type == "lagrangian":
+        required_attrs += ["domain"]
+    if trajectory_type == "eulerian" and ds_traj.attrs.get("timestep") == "domain_data":
+        required_attrs += ["domain"]
+
     missing_attrs = list(filter(lambda f: f not in ds_traj.attrs, required_attrs))
 
     if len(missing_attrs) > 0:

--- a/lagtraj/utils/validation.py
+++ b/lagtraj/utils/validation.py
@@ -25,9 +25,9 @@ def validate_trajectory(ds_traj):
 
     trajectory_type = ds_traj.attrs.get("trajectory_type")
     if trajectory_type == "lagrangian":
-        required_attrs += ["domain"]
+        required_attrs += ["domain_name"]
     if trajectory_type == "eulerian" and ds_traj.attrs.get("timestep") == "domain_data":
-        required_attrs += ["domain"]
+        required_attrs += ["domain_name"]
 
     missing_attrs = list(filter(lambda f: f not in ds_traj.attrs, required_attrs))
 


### PR DESCRIPTION
Closes https://github.com/EUREC4A-UK/lagtraj/issues/112

For Eulerian trajectories we either define a fixed timestep (e.g.
`PT1H`) and don't need domain data (and so the domain shouldn't be
given) or we are using timesteps from the domain data (in which case the
domain to use needs to be defined)

This introduces a special flag `__is_set__` for variables in input
definitions in that require that other variables are set.