### PR TITLE
Ensure tests are run outside local path

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,9 @@ from unittest.mock import patch
 import importlib
 
 import lagtraj.forcings.create
+from lagtraj.forcings import build_forcing_data_path
 import lagtraj.trajectory.create
+from lagtraj.trajectory import build_data_path as build_trajectory_data_path
 
 from test_forcing_profiles_extraction import AVAILABLE_CONVERSIONS
 
@@ -22,7 +24,12 @@ def test_cli(download_complete_mocked, testdata_info):
     ]
     lagtraj.trajectory.create.cli(args=args)
 
-    for conversion in AVAILABLE_CONVERSIONS:
+    # sort ensure `None` comes first
+    conversions = sorted(AVAILABLE_CONVERSIONS, key=lambda x: (x is not None, x))
+
+    # conversion creation where the non-converted forcing already exists,
+    # beacuse `conversion=None` is run first
+    for conversion in conversions:
         args = [
             testdata_info["forcing_name"],
             "--data-path",
@@ -32,3 +39,40 @@ def test_cli(download_complete_mocked, testdata_info):
         if conversion is not None:
             args += ["--conversion", conversion]
         lagtraj.forcings.create.cli(args=args)
+
+    # cleanup, remove all saved forcings
+    for conversion in conversions:
+        p_forcing = build_forcing_data_path(
+            root_data_path=testdata_info["testdata_path"],
+            forcing_name=testdata_info["forcing_name"],
+            conversion_name=conversion,
+        )
+        p_forcing.unlink()
+
+    # conversion creation where the non-converted forcing doesn't exist
+    for conversion in conversions:
+        args = [
+            testdata_info["forcing_name"],
+            "--data-path",
+            str(testdata_info["testdata_path"]),
+        ]
+
+        if conversion is not None:
+            args += ["--conversion", conversion]
+        lagtraj.forcings.create.cli(args=args)
+
+        # delete saved forcing
+        p_forcing = build_forcing_data_path(
+            root_data_path=testdata_info["testdata_path"],
+            forcing_name=testdata_info["forcing_name"],
+            conversion_name=conversion,
+        )
+        p_forcing.unlink()
+
+    # cleanup in case we run the CLI test again, the test will fail if we try
+    # to overwrite an existing file
+    p_traj = build_trajectory_data_path(
+        root_data_path=testdata_info["testdata_path"],
+        trajectory_name=testdata_info["trajectory_name"],
+    )
+    p_traj.unlink()

--- a/tests/test_forcing_profiles_extraction.py
+++ b/tests/test_forcing_profiles_extraction.py
@@ -4,6 +4,7 @@ import pytest
 import lagtraj.forcings.create
 from lagtraj.forcings import ForcingLevelsDefinition, ForcingSamplingDefinition
 from lagtraj.utils import validation
+import tempfile
 
 
 AVAILABLE_CONVERSIONS = [None, "lagtraj://kpt", "lagtraj://dephy"]
@@ -53,6 +54,11 @@ def test_create_forcing_linear_trajectory(
     # to enable export to file of a forcing we much give it a name
     ds_forcing.attrs["name"] = "test_forcing"
     if conversion_name is not None:
+        # we export to a temporary directory so that we don't clobber local
+        # files or have parallel tests clobber each other
+        tmpdir = tempfile.TemporaryDirectory()
         lagtraj.forcings.conversion.process.export_for_target(
-            ds_forcing=ds_forcing, conversion_name=conversion_name,
+            ds_forcing=ds_forcing,
+            conversion_name=conversion_name,
+            root_data_path=tmpdir.name,
         )

--- a/tests/test_input_definition_examples.py
+++ b/tests/test_input_definition_examples.py
@@ -48,7 +48,7 @@ INPUT_DEFN_EXAMPLES = _get_examples()
 
 
 @pytest.mark.parametrize("input_example", INPUT_DEFN_EXAMPLES)
-def test_load_example(input_example):
+def test_load_example(input_example, testdata_info):
     i = input_example.index("/")
     input_type_plural = input_example[:i]
     input_name = f"lagtraj://{input_example[i + 1 :]}"
@@ -61,7 +61,7 @@ def test_load_example(input_example):
     input_defn = lagtraj.input_definitions.load.load_definition(
         input_name=input_name,
         input_type=input_type,
-        root_data_path=DEFAULT_ROOT_DATA_PATH,
+        root_data_path=testdata_info["testdata_path"],
         required_fields=INPUT_TYPES[input_type],
     )
 


### PR DESCRIPTION
Related to https://github.com/EUREC4A-UK/lagtraj/issues/114

Previously some tests wrote and read from the local path (i.e. used this
path as the "data root"). This meant that if for example the yaml-files
have been changed locally the tests might fail, even though nothing was
actually broken with the tests. This is now fixed by ensuring that all
tests write to either the temporary data path or to generic temporary
paths.

The CLI tests were also modified to ensure that all tests remove their
output (in case they are run multiple times) and to ensure conversions
work both from existing forcing files and when no existing forcing file
exists.