### PR TITLE
Add help-text when CDS api for era5 isn't set up

### DIFF
--- a/lagtraj/domain/sources/era5/download.py
+++ b/lagtraj/domain/sources/era5/download.py
@@ -29,7 +29,16 @@ def download_data(
         )
     )
 
-    c = RequestFetchCDSClient()
+    try:
+        c = RequestFetchCDSClient()
+    except Exception as ex:
+        if str(ex).startswith("Missing/incomplete configuration file"):
+            raise Exception(
+                "To download ERA5 data you will first need to set up the"
+                " CDS API, details: https://cds.climate.copernicus.eu/api-how-to"
+            )
+        else:
+            raise
 
     try:
         with open(path / DATA_REQUESTS_FILENAME, "r") as fh:


### PR DESCRIPTION
Add more useful help text than the default exception raised by the CDS api module. The new help text includes a link to the CDS api website on setup instructions