### PR TITLE
Improve download completion check for ERA5

### DIFF
--- a/lagtraj/domain/download.py
+++ b/lagtraj/domain/download.py
@@ -1,20 +1,22 @@
-import dateutil.parser
+import datetime
 from pathlib import Path
 from time import sleep
-import datetime
 
-from .sources import era5
+import dateutil.parser
+
 from .. import DEFAULT_ROOT_DATA_PATH
-from . import LatLonBoundingBox, LatLonSamplingResolution, build_domain_data_path
-from .load import load_definition
 from ..trajectory.load import load_definition as load_traj_definition
+from . import (LatLonBoundingBox, LatLonSamplingResolution,
+               build_domain_data_path)
+from .load import load_definition
+from .sources import era5
 
 
 def download(
     data_path,
     source,
-    t_start,
-    t_end,
+    start_date,
+    end_date,
     bbox,
     latlon_sampling,
     version,
@@ -22,15 +24,15 @@ def download(
 ):
     """
     Download all data from a given `source` (fx `era5`) to `data_path` over time
-    range `t_start` to `t_end`, in `bbox` with `latlon_sampling` and store it
+    range `start_date` to `end_date`, in `bbox` with `latlon_sampling` and store it
     with `version` as the version of this domain.
     """
 
     if source.lower() == "era5":
         era5.download_data(
             path=data_path,
-            t_start=t_start,
-            t_end=t_end,
+            start_date=start_date,
+            end_date=end_date,
             bbox=bbox,
             latlon_sampling=latlon_sampling,
             overwrite_existing=overwrite_existing,
@@ -65,8 +67,8 @@ def download_named_domain(
     download(
         data_path=domain_data_path,
         source=domain_params["source"],
-        t_start=start_date,
-        t_end=end_date,
+        start_date=start_date,
+        end_date=end_date,
         bbox=bbox,
         latlon_sampling=latlon_sampling,
         overwrite_existing=overwrite_existing,
@@ -74,7 +76,11 @@ def download_named_domain(
     )
 
 
-def download_complete(root_data_path, domain_name):
+def download_complete(root_data_path, domain_name, start_date, end_date):
+    """
+    Check that all files have been downloaded and that they contain the data in
+    the expected date range
+    """
     domain_params = load_definition(domain_name=domain_name, data_path=root_data_path)
     source = domain_params["source"]
 
@@ -82,22 +88,46 @@ def download_complete(root_data_path, domain_name):
         root_data_path=root_data_path, domain_name=domain_params["name"]
     )
 
+    bbox = LatLonBoundingBox(
+        lat_min=domain_params["lat_min"],
+        lon_min=domain_params["lon_min"],
+        lat_max=domain_params["lat_max"],
+        lon_max=domain_params["lon_max"],
+    )
+
+    latlon_sampling = LatLonSamplingResolution(
+        lat=domain_params["lat_samp"], lon=domain_params["lon_samp"]
+    )
+
     if source.lower() == "era5":
-        return era5.all_data_is_downloaded(path=domain_data_path)
+        all_data_downloaded = era5.all_data_is_downloaded(
+            path=domain_data_path,
+            start_date=start_date,
+            end_date=end_date,
+            bbox=bbox,
+            latlon_sampling=latlon_sampling,
+        )
     else:
         raise NotImplementedError(
             "Source type `{}` unknown. Should for example be 'era5'".format(source)
         )
 
+    if not all_data_downloaded:
+        return False
 
-def _run_cli(timedomain_lookup="by_arguments"):
+
+def _parse_date(s):
+    return dateutil.parser.parse(s).date()
+
+
+def _run_cli(args=None, timedomain_lookup="by_arguments"):
     import argparse
 
     argparser = argparse.ArgumentParser()
     if timedomain_lookup == "by_arguments":
         argparser.add_argument("domain")
-        argparser.add_argument("start_date", type=dateutil.parser.parse)
-        argparser.add_argument("end_date", type=dateutil.parser.parse)
+        argparser.add_argument("start_date", type=_parse_date)
+        argparser.add_argument("end_date", type=_parse_date)
     elif timedomain_lookup == "by_trajectory":
         argparser.add_argument("trajectory")
     else:
@@ -115,7 +145,8 @@ def _run_cli(timedomain_lookup="by_arguments"):
         type=float,
         help="Retry time delay (in minutes) when some files are still processing",
     )
-    args = argparser.parse_args()
+
+    args = argparser.parse_args(args=args)
 
     if timedomain_lookup == "by_arguments":
         domain = args.domain
@@ -143,7 +174,9 @@ def _run_cli(timedomain_lookup="by_arguments"):
     if args.retry_rate is not None:
         while True:
             attempt_download()
-            if download_complete(args.data_path, domain_name=domain):
+            if download_complete(
+                args.data_path, domain_name=domain, start_date=t_min, end_date=t_max
+            ):
                 break
             else:
                 t_now = datetime.datetime.now()

--- a/lagtraj/domain/sources/era5/download.py
+++ b/lagtraj/domain/sources/era5/download.py
@@ -5,7 +5,6 @@ import datetime
 import warnings
 from pathlib import Path
 
-import netCDF4
 import yaml
 import requests
 
@@ -19,13 +18,34 @@ TIME_FORMAT = "%h:%M:%s"
 REPOSITORY_NAME = "reanalysis-era5-complete"
 
 
+def _normalise_date(d):
+    if isinstance(d, datetime.datetime):
+        warnings.warn(
+            "the era5 downloader for lagtraj downloads data in blocks of days"
+            f" and so the time component of the provided datetime `{d}` will be ignored"
+        )
+        return d.date()
+    return d
+
+
 def download_data(
-    path, t_start, t_end, bbox, latlon_sampling, version, overwrite_existing=False
+    path, start_date, end_date, bbox, latlon_sampling, version, overwrite_existing=False
 ):
+    """
+    Queue and download ERA5 data from ECMWF using the CDSAPI in the time range
+    `start_date` to `end_date` into a local directory defined by `path` and give this
+    dataset a specific `version`. The lat/lon sampling resolution is given by
+    `latlon_sampling`. Download is split into individual files per day,
+    run-type (analysis or forecast) and height-level (model or surface). Un
+    less `overwite_existing==True` only missing files will be queued and
+    downloaded.
+    """
+    start_date = _normalise_date(start_date)
+    end_date = _normalise_date(end_date)
 
     dl_queries = list(
         _build_queries(
-            t_start=t_start, t_end=t_end, bbox=bbox, latlon_sampling=latlon_sampling
+            start_date=start_date, end_date=end_date, bbox=bbox, latlon_sampling=latlon_sampling
         )
     )
 
@@ -131,7 +151,34 @@ def download_data(
         print("All files downloaded!")
 
 
-def all_data_is_downloaded(path):
+def all_data_is_downloaded(path, start_date, end_date, bbox, latlon_sampling):
+    """
+    Check if all data has been downloaded in the request time interval,
+    bounding-box and resolution.
+    """
+    start_date = _normalise_date(start_date)
+    end_date = _normalise_date(end_date)
+
+    dl_queries = list(
+        _build_queries(
+            start_date=start_date, end_date=end_date, bbox=bbox, latlon_sampling=latlon_sampling
+        )
+    )
+
+    # check if any files don't exist locally yet
+    # NOTE: this will not check if files are only partially downloaded
+    for output_filename, _ in dl_queries:
+        fp = (Path(path) / output_filename)
+        if not fp.exists():
+            return False
+
+    return True
+
+
+def data_backend_is_processing_requests(path):
+    """
+    Check if the CDSAPI is still processing some of the data requests
+    """
     c = RequestFetchCDSClient()
     return len(_get_files(path=path, c=c, with_status=["queued", "running"])) == 0
 
@@ -170,7 +217,7 @@ def _get_files(path, c, debug=False, with_status=None):
     return files
 
 
-def _build_query_times(model_run_type, t_start, t_end):
+def _build_query_times(model_run_type, start_date, end_date):
     """
     We currently download era5 data by date, build the query dates as datetime
     objects in the request time range
@@ -178,19 +225,19 @@ def _build_query_times(model_run_type, t_start, t_end):
     """
     if model_run_type == "an":
         return [
-            (t_start + datetime.timedelta(days=x))
-            for x in range(0, (t_end.date() - t_start.date()).days + 1)
+            (start_date + datetime.timedelta(days=x))
+            for x in range(0, (end_date - start_date).days + 1)
         ]
     elif model_run_type == "fc":
         return [
-            (t_start + datetime.timedelta(days=x))
-            for x in range(-1, (t_end.date() - t_start.date()).days + 1)
+            (start_date + datetime.timedelta(days=x))
+            for x in range(-1, (end_date - start_date).days + 1)
         ]
     else:
         raise NotImplementedError(model_run_type)
 
 
-def _build_queries(t_start, t_end, bbox, latlon_sampling):
+def _build_queries(start_date, end_date, bbox, latlon_sampling):
     """
     Return a list of cdsapi query arguments for any files that don't already
     exist
@@ -200,7 +247,7 @@ def _build_queries(t_start, t_end, bbox, latlon_sampling):
 
     for model_run_type in model_run_types:
         query_times = _build_query_times(
-            model_run_type=model_run_type, t_start=t_start, t_end=t_end
+            model_run_type=model_run_type, start_date=start_date, end_date=end_date
         )
         for level_type in level_types:
             for t in query_times:

--- a/lagtraj/domain/sources/era5/load.py
+++ b/lagtraj/domain/sources/era5/load.py
@@ -27,10 +27,14 @@ def _era_5_normalise_longitude(ds):
         """Sets longitude to be between -180 and 180 degrees"""
         return (longitude + 180.0) % 360.0 - 180.0
 
-    ds.coords["longitude"] = (
-        "longitude",
-        np.round(longitude_set_meridian(ds.coords["longitude"]), decimals=4),
-        ds.coords["longitude"].attrs,
+    longitude_values = ds.coords["longitude"].data
+    longitude_values_rounded_normed = np.round(
+        longitude_set_meridian(longitude_values), decimals=4
+    )
+    ds.coords["longitude"] = xr.DataArray(
+        longitude_values_rounded_normed,
+        name="longitude",
+        attrs=ds.coords["longitude"].attrs,
     )
     return ds
 
@@ -206,7 +210,10 @@ class ERA5DataSet(object):
                     slices[d] = s
 
             ds_v_slice = ds[variables].sel(
-                **slices, method=method, tolerance=tolerance, drop=drop,
+                **slices,
+                method=method,
+                tolerance=tolerance,
+                drop=drop,
             )
             ds_v_slice.load()
             # Change the long name of these variables, so the units are no

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-xarray
+xarray>=0.16.0
 pytest
 netCDF4
 datetime


### PR DESCRIPTION
- [x] Update xarray version to v0.16.0 to enable use of `date` datetime accessor on time coordinates `da.dt.date`
- [ ] fix bug in ERA5 longitude normalisation which raises error in xarray
- [ ] rename all `t_start` -> `start_date` and `t_end` -> `end_date` and warn user if `datetime.datetime` object is passed in instead of `datetime.date` object. We previously ignore the time component anyway (because we fetch files by date) and `start_date` reflects this better than `t_start`.