### PR TITLE
Persist test-data when test-data dir set

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -127,14 +127,13 @@ export PYTEST_ADDOPTS='--pdb --pdbcls=IPython.terminal.debugger:Pdb'
 
 ### Speeding up testing
 
-If you are running the tests repeatedly it's a good idea to download the
-testdata locally and point lagtraj to where it resides (otherwise lagtraj will
-attempt to download the testdata every time the tests are run):
+If you are running the tests repeatedly it's a good idea to ensure that the
+test-data isn't downloaded anew every time the tests are run. To do this you
+just neeed to set the environment variable `LAGTRAJ_TESTDATA_DIR` to set the
+directory where you would like the test-data to be persisted (the directory
+will be created for you if it doesn't already exist):
 
 ```bash
-wget http://gws-access.ceda.ac.uk/public/eurec4auk/testdata/lagtraj.testdata.tar.gz
-mkdir /tmp/lagtraj
-tar zxvf lagtraj.testdata.tar.gz -C /tmp/lagtraj
 export LAGTRAJ_TESTDATA_DIR=/tmp/lagtraj
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ TESTDATA_URL = "http://gws-access.jasmin.ac.uk/public/eurec4auk/testdata/lagtraj
 
 if os.environ.get("LAGTRAJ_TESTDATA_DIR", None):
     TESTDATA_DIR = Path(os.environ["LAGTRAJ_TESTDATA_DIR"])
-    USING_PERSISTANT_TESTDIR = True
+    USING_PERSISTENT_TESTDIR = True
 else:
     tempdir = tempfile.TemporaryDirectory()
     TESTDATA_DIR = Path(tempdir.name)
@@ -29,7 +29,7 @@ else:
         "LAGTRAJ_TESTDATA_DIR=/tmp/lagtraj` in your command prompt "
         "(the directory will be created if it doesn't already exist)"
     )
-    USING_PERSISTANT_TESTDIR = False
+    USING_PERSISTENT_TESTDIR = False
 
 
 def _download_testdata():
@@ -43,7 +43,7 @@ def _download_testdata():
 
 
 def ensure_testdata_available():
-    if USING_PERSISTANT_TESTDIR:
+    if USING_PERSISTENT_TESTDIR:
         TESTDATA_DIR.mkdir(exist_ok=True, parents=True)
     elif not TESTDATA_DIR.exists():
         raise Exception(f"Couldn't find test-data directory {TESTDATA_DIR}")


### PR DESCRIPTION
Can now set the directory into which test-data will be persisted (so that re-download of test-data can be avoided) using the `LAGTRAJ_TESTDATA_DIR` environment variable. Fix development notes to indicate this new functionality.

Closes https://github.com/EUREC4A-UK/lagtraj/issues/166