### PR TITLE
Ensure package data included with install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased](https://github.com/EUREC4A-UK/lagtraj/tree/HEAD)
+
+[Full Changelog](https://github.com/EUREC4A-UK/lagtraj/compare/v0.1.0...HEAD)
+
+*bugfixes*
+
+- ensure package data (example input definitions and ERA5 level definitions)
+  are installed when installing `lagtraj` from pypi
+  [\#178](https://github.com/EUREC4A-UK/lagtraj/pull/178) @leifdenby
+
+
 ## [v0.1.0](https://github.com/EUREC4A-UK/lagtraj/tree/v0.1.0)
 
 [Full Changelog](https://github.com/EUREC4A-UK/lagtraj/compare/...v0.1.0)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,13 @@
-include versioneer.py
-include lagtraj/_version.py
-recursive-include lagtraj/input_definitions/examples_files *
+include *.in
+include *.md
+include *.txt
+include *.yaml
+recursive-include docs *.bib
+recursive-include docs *.md
+recursive-include docs *.png
+recursive-include docs *.tex
+recursive-include lagtraj *.dat
+recursive-include lagtraj *.yaml
+
+# added by check-manifest
+recursive-include tests *.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
   psutil
   semver==2.13.0
   numba
+include_package_data = true
 
 [options.packages.find]
 where=.


### PR DESCRIPTION
Previously `setup.cfg` was missing the `include_package_data` setting and so package data wasn't being installed even though it was included in the built package.

Fixes https://github.com/EUREC4A-UK/lagtraj/issues/177