### PR TITLE
Fix bug in converted forcings filepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased](https://github.com/EUREC4A-UK/lagtraj/tree/HEAD)
+
+[Full Changelog](https://github.com/EUREC4A-UK/lagtraj/compare/v0.1.1...HEAD)
+
+*bugfixes*
+
+- fix for forcing conversion input definition filepath (to remove
+  `lagtraj://`-prefix) [\#185](https://github.com/EUREC4A-UK/lagtraj/pull/185)
+  @leifdenby
+
+
 ## [v0.1.1](https://github.com/EUREC4A-UK/lagtraj/tree/v0.1.1)
 
 [Full Changelog](https://github.com/EUREC4A-UK/lagtraj/compare/v0.1.0...v0.1.1)

--- a/lagtraj/forcings/conversion/load.py
+++ b/lagtraj/forcings/conversion/load.py
@@ -20,7 +20,7 @@ def _get_definition_parameters(root_data_path, forcing_name, conversion_name):
     if conversion_name.startswith(LAGTRAJ_EXAMPLES_PATH_PREFIX):
         params_defn_expected_local_path = build_input_definition_path(
             root_data_path=root_data_path,
-            input_name=forcing_name,
+            input_name=forcing_name.replace(LAGTRAJ_EXAMPLES_PATH_PREFIX, ""),
             input_type="forcing",
             input_subtype=conversion_name.replace(LAGTRAJ_EXAMPLES_PATH_PREFIX, ""),
         )
@@ -31,15 +31,15 @@ def _get_definition_parameters(root_data_path, forcing_name, conversion_name):
             required_fields=INPUT_REQUIRED_FIELDS,
             expected_local_path=params_defn_expected_local_path,
         )
-        return conversion_defn
     else:
-        return load.load_definition(
+        conversion_defn = load.load_definition(
             root_data_path=root_data_path,
             input_name=forcing_name,
             input_type="forcing",
             input_subtype=conversion_name,
             required_fields=INPUT_REQUIRED_FIELDS,
         )
+    return conversion_defn
 
 
 def load_definition(root_data_path, forcing_name, conversion_name):

--- a/lagtraj/input_definitions/__init__.py
+++ b/lagtraj/input_definitions/__init__.py
@@ -1,11 +1,23 @@
 import semver
 
 from .. import build_data_path
+from .examples import LAGTRAJ_EXAMPLES_PATH_PREFIX
 
 
 def build_input_definition_path(
     root_data_path, input_name, input_type, input_subtype=None
 ):
+    if LAGTRAJ_EXAMPLES_PATH_PREFIX in input_name:
+        raise Exception(
+            f"Can't build local path to input definition with name `{input_name}`."
+            f" Remove lagtraj-bundle prefix `{LAGTRAJ_EXAMPLES_PATH_PREFIX}` and try again"
+        )
+    if LAGTRAJ_EXAMPLES_PATH_PREFIX in input_type:
+        raise Exception(
+            f"Can't build local path to input definition with name `{input_type}`"
+            f" Remove lagtraj-bundle prefix `{LAGTRAJ_EXAMPLES_PATH_PREFIX}` and try again"
+        )
+
     data_path = build_data_path(root_data_path=root_data_path, data_type=input_type)
 
     if input_subtype is None:

--- a/lagtraj/input_definitions/load.py
+++ b/lagtraj/input_definitions/load.py
@@ -38,9 +38,15 @@ def load_definition(
 ):
     params = None
     input_path = None
-    requesting_lagtraj_bundled_input = input_name.startswith(
-        LAGTRAJ_EXAMPLES_PATH_PREFIX
-    )
+    if input_subtype is None:
+        requesting_lagtraj_bundled_input = input_name.startswith(
+            LAGTRAJ_EXAMPLES_PATH_PREFIX
+        )
+    else:
+        input_name = input_name.replace(LAGTRAJ_EXAMPLES_PATH_PREFIX, "")
+        requesting_lagtraj_bundled_input = input_subtype.startswith(
+            LAGTRAJ_EXAMPLES_PATH_PREFIX
+        )
 
     if requesting_lagtraj_bundled_input:
         try:
@@ -122,11 +128,16 @@ def load_definition(
             )
             if not input_path.exists():
                 input_type_plural = DATA_TYPE_PLURAL[input_type]
+                if input_subtype is None:
+                    input_desc = input_type
+                else:
+                    input_desc = f"{input_subtype} {input_type}"
+
                 raise Exception(
-                    f"The requested {input_type} ({input_name}) wasn't found. "
-                    f"To use a {input_type} with this name please define its "
-                    f"parameters {input_path}\n"
-                    "(or run `python -m lagtraj.input_definitions.examples` all available with"
+                    f"The requested input definition for creating {input_desc} `{input_name}` wasn't found. "
+                    f"To create a {input_desc} with this name please define its "
+                    f"parameters in {input_path}\n"
+                    "(or run `python -m lagtraj.input_definitions.examples` all available with "
                     "to see the ones currently bundled with lagtraj"
                 )
             print()

--- a/lagtraj/input_definitions/load.py
+++ b/lagtraj/input_definitions/load.py
@@ -36,6 +36,35 @@ def load_definition(
     input_subtype=None,
     expected_local_path=None,
 ):
+    """
+    load the input definition of a given type (`input_type`, for example
+    `domain`, `trajectory` or `forcing`) and name (for example
+    `eurec4a_circle_data`) looking within a specific root data-path
+    (`root_data_path`). The returned input definition will be a dictionary. The
+    lookup path for a given input definition is:
+
+        `{root_data_path}/{input_type}s/{input_name}.yaml`
+
+    In the case where the `input_name` has the `lagtraj://`-prefix
+    `load_definition` has some special behaviour:
+    - the lookup path used will instead be internally in lagtraj, i.e. using
+      this prefix enables the use of input definitions bundled with lagtraj
+    - the bundled input definition will be copied to the matching path within
+      `root_data_path`, before this copy is done though a check is made to
+      ensure the local copy of the input definition hasn't been modified (to
+      avoid overwriting any user-changes). In this case lagtraj will emit an
+      exception and instruct the user to remove the `lagtraj://`-prefix, so
+      that the locally modified input definition is used instead.
+
+    `input_subtype` was added to handle the case of producing input definitions
+    for conversion of forcings to specific models. These input definitions
+    behave differently from the rest as an input definition that describes a
+    forcing conversion is stored to describe conversion for a specific forcing
+    (in `{root_data_path}/forcings/{input_name}.{input_subtype}.yaml`) but
+    internally in lagtraj they are stored without reference to a specific
+    forcing (in `{lagtraj_root}/forcing_conversions/{input_submit}.yaml`) so
+    that they can be applied generally to any forcing.
+    """
     params = None
     input_path = None
     if input_subtype is None:
@@ -57,9 +86,10 @@ def load_definition(
             else:
                 if input_type == "forcing":
                     # NB: this is a bit hacky, we're assuming that the
-                    # "subtype" will refer to a converted forcing, but that is
-                    # probably ok for now, it's unlikely that we will have other
-                    # kinds of subtypes of forcings
+                    # "subtype" will refer to how a forcing should be
+                    # converted, but that is probably ok for now since it's
+                    # unlikely that we will have extra sub-types (besides for
+                    # forcings)
                     try:
                         input_path = input_examples.get_path(
                             input_name=f"lagtraj://{input_subtype}",


### PR DESCRIPTION
Previously the lagtraj prefix (`lagtraj://`) was erroneously included in the filepath of the yaml-file defining how the conversion is done.

Closes https://github.com/EUREC4A-UK/lagtraj/issues/184