### PR TITLE
Bump CI python to v3.8

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install ncview
       run: sudo apt-get install ncview
     - name: Install dependencies

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install ncview
       run: sudo apt-get install ncview
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 *maintenance*
 
-- switch to using python v3.7 for continuous integration
+- switch to using python v3.8 for continuous integration
   [\#186](https://github.com/EUREC4A-UK/lagtraj/pull/186) @leifdenby
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   formatted output files
   [\#182](https://github.com/EUREC4A-UK/lagtraj/pull/182/) @sjboeing
 
+*maintenance*
+
+- switch to using python v3.7 for continuous integration
+  [\#186](https://github.com/EUREC4A-UK/lagtraj/pull/186) @leifdenby
+
 
 ## [v0.1.1](https://github.com/EUREC4A-UK/lagtraj/tree/v0.1.1)
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ $> python -m pip install lagtraj
 *NOTE: if you are intending to modify `lagtraj` yourself you should check out
 the [development notes](docs/developing.md).*
 
-`lagtraj` requires Python 3 and is tested with `python3.7` but later
-versions should work too.
+`lagtraj` requires Python 3 and is developed and tested with `python3.8` but later
+versions should work too (it may work with earlier versions too).
 
 Once installed all `lagtraj`'s commands are available from any directory
 and the follow the pattern

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ $> python -m pip install lagtraj
 *NOTE: if you are intending to modify `lagtraj` yourself you should check out
 the [development notes](docs/developing.md).*
 
-`lagtraj` requires Python 3 and is developed and tested with `python3.8` but later
+`lagtraj` requires Python 3 and is developed and tested with `python3.8` (in
+that we aim to follow the recommendations of
+[NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html)) but later
 versions should work too (it may work with earlier versions too).
 
 Once installed all `lagtraj`'s commands are available from any directory

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $> python -m pip install lagtraj
 *NOTE: if you are intending to modify `lagtraj` yourself you should check out
 the [development notes](docs/developing.md).*
 
-`lagtraj` requires Python 3 and is tested with `python3.6` but later
+`lagtraj` requires Python 3 and is tested with `python3.7` but later
 versions should work too.
 
 Once installed all `lagtraj`'s commands are available from any directory


### PR DESCRIPTION
Github actions CI doens't support python 3.6 anymore, so we need to start using python v3.7 for testing