### PR TITLE
Fix shown example with bundled examples cli cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 *bugfixes*
 
+- fix text shown when using CLI command to list lagtraj bundled examples
+  [\#187](https://github.com/EUREC4A-UK/lagtraj/pull/187) @leifdenby
+
 - fix for forcing conversion input definition filepath (to remove
   `lagtraj://`-prefix) [\#185](https://github.com/EUREC4A-UK/lagtraj/pull/185)
   @leifdenby

--- a/lagtraj/input_definitions/examples.py
+++ b/lagtraj/input_definitions/examples.py
@@ -73,14 +73,16 @@ def cli(args=None):
 
     print_available()
 
+    first_available_domain = list(get_available(input_types=["domains"])["domains"])[0]
+
     print("\n")
     print(
-        "To use for example the `eurec4a_north_atlantic` domain definition\n"
-        "for downloading domain data run lagtraj.domain.download as"
-        " follows:\n"
+        f"To use for example the `{first_available_domain}` domain definition\n"
+        "for downloading domain data for Feb 1st to 3rd 2020 run"
+        " lagtraj.domain.download as follows:\n"
         "\n"
         "    $> python -m lagtraj.domain.download"
-        " lagtraj://eurec4a_20200202_first"
+        f" lagtraj://{first_available_domain} 2020/02/01 2020/02/03"
     )
 
 


### PR DESCRIPTION
Fix example shown when running `python -m
lagtraj.input_definitions.examples` CLI command. Previously the returned command wasn't valid.

Currently on `master`:
```bash
$> python -m lagtraj.input_definitions.examples
The following domain/forcing/trajectory definitions are currently included with lagtraj:

lagtraj://
 ├── domains
 │   ├── eurec4a_north_atlantic
 │   ├── eurec4a_circle
 │   └── drydown_cardington_local
 ├── trajectories
 │   ├── eurec4a_20200103_lag_testcase
 │   ├── eurec4a_20200202_first_short_press
 │   ├── eurec4a_20200202_first
 │   ├── eurec4a_20200209_first
 │   ├── drydown_cardington_20200420_00_eul
 │   ├── eurec4a_20200205_second
 │   ├── eurec4a_20200207_first
 │   ├── eurec4a_campaign_eulerian
 │   ├── eurec4a_20200128_first
 │   ├── eurec4a_20200202_first_short_eul
 │   └── eurec4a_20200202_first_short
 ├── forcings_conversion
 │   ├── dephy_prescribed_rad
 │   ├── kpt__120_levels
 │   ├── kpt
 │   └── dephy
 └── forcings
     ├── eurec4a_20200103_lag_testcase
     ├── eurec4a_20200202_first_short_press
     ├── eurec4a_20200202_first
     ├── eurec4a_20200209_first
     ├── drydown_cardington_20200420_00_eul
     ├── eurec4a_20200205_second
     ├── eurec4a_20200207_first
     ├── eurec4a_campaign_eulerian
     ├── eurec4a_20200128_first
     ├── eurec4a_20200202_first_short_eul
     └── eurec4a_20200202_first_short


To use for example the `eurec4a_north_atlantic` domain definition
for downloading domain data run lagtraj.domain.download as follows:

    $> python -m lagtraj.domain.download lagtraj://eurec4a_20200202_first
```

The suggested command at the bottom is missing the `start_date` and `end_date` arguments, and `eurec4a_20200202_first` isn't a valid `domain` example.