### PR TITLE
add zenodo doi badge and citation file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [unreleased](https://github.com/EUREC4A-UK/lagtraj/tree/HEAD)
+
+[Full Changelog](https://github.com/EUREC4A-UK/lagtraj/compare/v0.1.2...HEAD)
+
+*maintenance*
+
+- add Zenodo integration and add citation file
+  [\#195](https://github.com/EUREC4A-UK/lagtraj/pull/195) @leifdenby
+
+
 ## [v0.1.2](https://github.com/EUREC4A-UK/lagtraj/tree/v0.1.2)
 
 [Full Changelog](https://github.com/EUREC4A-UK/lagtraj/compare/v0.1.1...v0.1.2)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: lagtraj
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Leif
+    family-names: Denby
+    email: leif@denby.eu
+    affiliation: University of Leeds
+    orcid: 'https://orcid.org/0000-0002-7611-9222'
+  - given-names: Steven
+    family-names: Böing
+    email: s.boeing@leeds.ac.uk
+    affiliation: University of Leeds
+    orcid: 'https://orcid.org/0000-0003-3794-2563'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # lagtraj Lagragian simulations trajectories
 
-![lagtraj](https://github.com/EUREC4A-UK/lagtraj/workflows/lagtraj/badge.svg)
-
-[![DOI](https://zenodo.org/badge/251601559.svg)](https://zenodo.org/badge/latestdoi/251601559)
+![lagtraj](https://github.com/EUREC4A-UK/lagtraj/workflows/lagtraj/badge.svg) [![DOI](https://zenodo.org/badge/251601559.svg)](https://zenodo.org/badge/latestdoi/251601559)
 
 ![trajectory example](docs/eurec4a_20191209_12_lag.png)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![lagtraj](https://github.com/EUREC4A-UK/lagtraj/workflows/lagtraj/badge.svg)
 
+[![DOI](https://zenodo.org/badge/251601559.svg)](https://zenodo.org/badge/latestdoi/251601559)
+
 ![trajectory example](docs/eurec4a_20191209_12_lag.png)
 
 


### PR DESCRIPTION
I've set up the zenodo integration for our github organisation which ensures the future releases on github area automatically uploaded to zenodo and given a DOI. I've also made sure that our existing releases on github have been pushed to zenodo (using https://github.com/imcf/zenodo-doi-for-existing-release). I've added a zenodo doi badge to the README and created a  `CITATION.cff` file as zenodo recommend you do (https://citation-file-format.github.io/).

Could you have a look @sjboeing and let me know if this looks ok to you?